### PR TITLE
feat: read api urls from runtime env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ WORKDIR /app
 
 COPY . .
 
-ARG SECRET_FILE
-COPY $SECRET_FILE ./.env
-
 RUN npm run install-all
 
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ npm run build-prod
 
 Now is ready to be deployed. All generated files are located at `out` folder, which you can deploy with any hosting service.
 
+### Runtime environment variables
+
+The production image reads its configuration from environment variables when the
+container starts. Provide the API URLs and secrets (for example
+`API_URL_TIENDANUBE`, `API_URL_VTEX`, `API_URL_WOOCOMMERCE`,
+`API_URL_PRESTASHOP` and `CRYPTOJS_SECRET_KEY`) through your deployment
+environment such as ConfigMaps or Secrets. A `.env` file is no longer required
+at build time.
+
 ### Testing
 
 All tests are colocated with the source code inside the same directory. So, it makes it easier to find them. Unfortunately, it is not possible with the `pages` folder which is used by Next.js for routing. So, what is why we have a `pages.test` folder to write tests from files located in `pages` folder.

--- a/next.config.js
+++ b/next.config.js
@@ -15,14 +15,4 @@ module.exports = withBundleAnalyzer({
   // So, the source code is "basePath-ready".
   // You can remove `basePath` if you don't need it.
   reactStrictMode: true,
-  env: {
-    API_URL: process.env.API_URL,
-    API_URL_TIENDANUBE: process.env.API_URL_TIENDANUBE,
-    API_URL_VTEX: process.env.API_URL_VTEX,
-    API_URL_WOOCOMMERCE: process.env.API_URL_WOOCOMMERCE,
-    API_URL_PRESTASHOP: process.env.API_URL_PRESTASHOP,
-    ECOMMERCE: process.env.ECOMMERCE,
-    CRYPTOJS_SECRET_KEY: process.env.CRYPTOJS_SECRET_KEY,
-    HOSTNAME: process.env.HOSTNAME,
-  },
 });

--- a/src/lib/ecommerces.ts
+++ b/src/lib/ecommerces.ts
@@ -1,23 +1,25 @@
+const env = (key: string) => process.env[key];
+
 export const ecommerces = {
   tiendanube: {
     id: 'tiendanube',
     name: 'Tiendanube',
-    apiUrl: process.env.API_URL_TIENDANUBE,
+    apiUrl: env('API_URL_TIENDANUBE'),
   },
   vtex: {
     id: 'vtex',
     name: 'VTEX',
-    apiUrl: process.env.API_URL_VTEX,
+    apiUrl: env('API_URL_VTEX'),
   },
   woocommerce: {
     id: 'woocommerce',
     name: 'Woocommerce',
-    apiUrl: process.env.API_URL_WOOCOMMERCE,
+    apiUrl: env('API_URL_WOOCOMMERCE'),
   },
   prestashop: {
     id: 'prestashop',
     name: 'Prestashop',
-    apiUrl: process.env.API_URL_PRESTASHOP,
+    apiUrl: env('API_URL_PRESTASHOP'),
   },
 };
 


### PR DESCRIPTION
## Summary
- remove env section from next config
- load ecommerce API URLs from runtime env vars
- document runtime env vars and remove build-time .env usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68952177c8c0832fabbfba726ba5a054