### PR TITLE
feat: embed api urls at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ npm run build-prod
 
 Now is ready to be deployed. All generated files are located at `out` folder, which you can deploy with any hosting service.
 
+### Build-time environment variables
+
+The Docker build expects a `.env` file containing the API URLs and secrets. Provide its path via the `SECRET_FILE` build argument. Values from this file are embedded during `npm run build` and available at runtime.
+
 ### Testing
 
 All tests are colocated with the source code inside the same directory. So, it makes it easier to find them. Unfortunately, it is not possible with the `pages` folder which is used by Next.js for routing. So, what is why we have a `pages.test` folder to write tests from files located in `pages` folder.


### PR DESCRIPTION
## Summary
- restore build-time env injection for API URLs
- copy .env via SECRET_FILE during Docker builds
- document build-time .env requirement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952177c8c0832fabbfba726ba5a054