### PR TITLE
refactor: allow build-time API URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-API_URL=https://oca-tiendanube-api.conexa.ai
-API_URL_VTEX=https://oca-vtex-api-stage.conexa.ai
-API_URL_TIENDANUBE=https://oca-tiendanube-api-stage.conexa.ai
-API_URL_WOOCOMMERCE=https://oca-tiendanube-api-stage.conexa.ai
-API_URL_PRESTASHOP=https://oca-tiendanube-api-stage.conexa.ai
+NEXT_PUBLIC_API_URL=https://plugins.ocadev.com.ar
+NEXT_PUBLIC_API_URL_VTEX=https://plugins.ocadev.com.ar/vtex/api/v1
+NEXT_PUBLIC_API_URL_TIENDANUBE=https://plugins.ocadev.com.ar/tiendanube/api/v1
+NEXT_PUBLIC_API_URL_WOOCOMMERCE=https://plugins.ocadev.com.ar/woocommerce/api/v1
+NEXT_PUBLIC_API_URL_PRESTASHOP=https://plugins.ocadev.com.ar/prestashop/api/v1
 NODE_ENV=development

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
+// Environment variables are provided via build-time args, so we do not set `env` here.
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
-module.exports = withBundleAnalyzer({
+const nextConfig = {
   output: 'standalone',
   eslint: {
     dirs: ['.'],
@@ -15,4 +16,6 @@ module.exports = withBundleAnalyzer({
   // So, the source code is "basePath-ready".
   // You can remove `basePath` if you don't need it.
   reactStrictMode: true,
-});
+};
+
+module.exports = withBundleAnalyzer(nextConfig);

--- a/src/lib/ecommerces.ts
+++ b/src/lib/ecommerces.ts
@@ -1,25 +1,23 @@
-const env = (key: string) => process.env[key];
-
 export const ecommerces = {
   tiendanube: {
     id: 'tiendanube',
     name: 'Tiendanube',
-    apiUrl: env('API_URL_TIENDANUBE'),
+    apiUrl: process.env.NEXT_PUBLIC_API_URL_TIENDANUBE,
   },
   vtex: {
     id: 'vtex',
     name: 'VTEX',
-    apiUrl: env('API_URL_VTEX'),
+    apiUrl: process.env.NEXT_PUBLIC_API_URL_VTEX,
   },
   woocommerce: {
     id: 'woocommerce',
     name: 'Woocommerce',
-    apiUrl: env('API_URL_WOOCOMMERCE'),
+    apiUrl: process.env.NEXT_PUBLIC_API_URL_WOOCOMMERCE,
   },
   prestashop: {
     id: 'prestashop',
     name: 'Prestashop',
-    apiUrl: env('API_URL_PRESTASHOP'),
+    apiUrl: process.env.NEXT_PUBLIC_API_URL_PRESTASHOP,
   },
 };
 


### PR DESCRIPTION
## Summary
- load API URLs from NEXT_PUBLIC_ env vars
- accept build args for API endpoints in Dockerfile
- clarify environment handling in Next.js config
- include base API URL build arg

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*
- `docker build --build-arg NEXT_PUBLIC_API_URL=https://plugins.ocadev.com.ar --build-arg NEXT_PUBLIC_API_URL_VTEX=https://plugins.ocadev.com.ar/vtex/api/v1 --build-arg NEXT_PUBLIC_API_URL_TIENDANUBE=https://plugins.ocadev.com.ar/tiendanube/api/v1 --build-arg NEXT_PUBLIC_API_URL_WOOCOMMERCE=https://plugins.ocadev.com.ar/woocommerce/api/v1 --build-arg NEXT_PUBLIC_API_URL_PRESTASHOP=https://plugins.ocadev.com.ar/prestashop/api/v1 -t conexa-front:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895fb49c034832fa9695805da3b896d